### PR TITLE
Add alias for "git clone"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![](https://api.codeclimate.com/v1/badges/410bbdeecc970066ba71/maintainability)](https://codeclimate.com/github/alexmacarthur/christian-git/maintainability)
 
-A collection of Christianized aliases to sanctify your Git workflow. 
+A collection of Christianized aliases to sanctify your Git workflow.
 
 ## What is this?
 
 Install this package and you'll have a collection of Christian-ese git aliases at your fingetips. You can use this package to completely replace your need to call `git` on your machine. If a Christian alias doesn't exist, it'll fall back to use the default command provided by Git.
 
-For example, `Jesus testimony` calls `git log`. 
+For example, `Jesus testimony` calls `git log`.
 
 | Command         | Alias       | Explanation
 | ------------- |---------------|--------
@@ -16,13 +16,14 @@ For example, `Jesus testimony` calls `git log`.
 | blame | judas | Truly I tell you, one of you will betray me.
 | branch | vine | He is the vine, we are the branches.
 | checkout | resurrect | Resurrect what was once alive.
+| clone | breadandfish | Jesus fed the 5000 with five loaves and two fish.
 | commit | save      | Commit your code to the Lord and it will be saved.
 | init | inthebeginning | Start us off, God.
 | log | testimony | Use your code's testimony to share the path the Lord has led you along.
 | merge | trinity | Father, Son, and Holy Spirit. Three in One.
 | pull | petition | Petition the Lord through prayer to grant you those remote code changes.
 | push | preach | Proudly declare your Gospel code to those who need it.
-| rebase | disciple | Regularly examine your code, words and actions and compare them with the Word of God. 
+| rebase | disciple | Regularly examine your code, words and actions and compare them with the Word of God.
 | reset | ark | God hit reset on the earth.
 | status        | walk | How's your code's walk with the Lord?
 | tag | testament | God's way of semantic versioning.

--- a/commands.js
+++ b/commands.js
@@ -10,6 +10,7 @@ module.exports = {
   blame: 'judas',         // Truly I tell you, one of you will betray me.
   branch: 'vine',         // He is the vine, we are the branches.
   checkout: 'resurrect',  // Resurrect what was once alive.
+  clone: 'breadandfish'   // Jesus fed the 5000 with five loaves and two fish.
   commit: 'save',         // Commit your code to the Lord and it will be saved.
   init: 'inthebeginning', // Start us off, God.
   log: 'testimony',       // Use your code's testimony to share the path the Lord has led you along.


### PR DESCRIPTION
After doing extensive research (roughly 42 seconds), I have come up with a rather Christian alias for `git clone`, and that's `git breadandfish`. This refers to when Jesus fed the 5000 by "cloning" five 🍞 and two 🐟.

Other considerations:

- `git eve` (God sort of cloned Adam? Okay not really, but you get the idea.)
- That's all I have.

It's a WIP. 🐑